### PR TITLE
changed comparator card type (fixes issue #56)

### DIFF
--- a/SmartKioskBot/Logic/Comparator.cs
+++ b/SmartKioskBot/Logic/Comparator.cs
@@ -314,7 +314,7 @@ namespace SmartKioskBot.Logic
                     }
                 }
 
-                cards.Add(ProductCard.GetProductCard(productsToCompare[kvp.Key], ProductCard.CardType.SEARCH).ToAttachment());
+                cards.Add(ProductCard.GetProductCard(productsToCompare[kvp.Key], ProductCard.CardType.COMPARATOR).ToAttachment());
             }
 
             string response = "";


### PR DESCRIPTION
Correct set of buttons was not being displayed because cards were created with the default card type (SEARCH)